### PR TITLE
Support distinguishing flavours

### DIFF
--- a/pkg/framework/spec.go
+++ b/pkg/framework/spec.go
@@ -12,13 +12,14 @@ type Test struct {
 
 	Name string `json:"name,omitempty"`
 
-	Values map[string]interface{} `json:"values,omitempty"`
-	Set    map[string]interface{} `json:"set,omitempty"`
-
-	Defs         string            `json:"defs,omitempty"`
-	Release      *ReleaseSpec      `json:"release,omitempty"`
-	Server       *ServerSpec       `json:"server,omitempty"`
-	Capabilities *CapabilitiesSpec `json:"capabilities,omitempty"`
+	Values       map[string]interface{} `json:"values,omitempty"`
+	Set          map[string]interface{} `json:"set,omitempty"`
+	Flavour      string                 `json:"flavour,omitempty"`
+	Condition    Condition              `json:"condition,omitempty"`
+	Defs         string                 `json:"defs,omitempty"`
+	Release      *ReleaseSpec           `json:"release,omitempty"`
+	Server       *ServerSpec            `json:"server,omitempty"`
+	Capabilities *CapabilitiesSpec      `json:"capabilities,omitempty"`
 
 	Expect      string `json:"expect,omitempty"`
 	ExpectError *bool  `json:"expectError,omitempty"`
@@ -30,6 +31,11 @@ type Test struct {
 
 	funcDefs   []*gojq.FuncDef
 	predicates []*gojq.Query
+}
+
+// Condition
+type Condition struct {
+	IfFlavour string `json:"ifFlavour,omitempty"`
 }
 
 // ReleaseSpec specifies how the release options for Helm will be constructed.

--- a/pkg/framework/test.go
+++ b/pkg/framework/test.go
@@ -88,9 +88,17 @@ func (t *Test) initialize() error {
 
 	for i, subTest := range t.Tests {
 		subTest.parent = t
+		if subTest.Flavour == "" {
+			subTest.Flavour = t.Flavour
+		}
 		if subTest.Name == "" {
 			subTest.Name = fmt.Sprintf("#%d", i)
 		}
+
+		if subTest.Flavour != "" {
+			subTest.Name = fmt.Sprintf("%s(%s)", subTest.Name, subTest.Flavour)
+		}
+
 		if err := subTest.initialize(); err != nil {
 			return errors.Wrapf(err, "initializing %q", subTest.Name)
 		}
@@ -114,6 +122,11 @@ func (t *Test) DoRun(testingT *testing.T, tgt *Target) {
 		for _, subTest := range t.Tests {
 			subTest.Run(testingT, tgt)
 		}
+		return
+	}
+
+	if t.Condition.IfFlavour != "" && t.Condition.IfFlavour != t.Flavour {
+		// We skip the test.
 		return
 	}
 


### PR DESCRIPTION
This work is part of a proof-of-concept for https://issues.redhat.com/browse/ROX-8711.

The basic idea here is that we would like to execute the Helm chart's test suite also in the case where we pre-render the chart files in "deployment bundle mode".

However, the difficulty is that in general the tests require some modification depending on whether executed in the "Helm chart mode" or in the "deployment bundle mode".

This PR extends the helmtest framework such that tests can be run selectively, depending on a "flavour" value, which is passed in by the user of helmtest and which can be accessed by the leave tests defined in the test suite.

