### PR TITLE
Makefile PATH fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PATH := $(GOBIN):$(PATH)
 # and so, without the following line, the shell does not end up
 # trying commands in $(GOBIN) first.
 # See https://stackoverflow.com/a/36226784/3690207
-SHELL := env GOBIN=$(GOBIN) PATH=$(PATH) /bin/bash
+SHELL := env GOBIN="$(GOBIN)" PATH="$(PATH)" /bin/bash
 
 ########################################
 ###### Binaries we depend on ###########


### PR DESCRIPTION
Apparently the Makefile currently does not handle whitespaces correctly in `PATH`.
```
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
➜  helmtest git:(main) ✗ PATH="/foo bar/bin:/usr/local/bin:/bin:/usr/bin" make go-generated-srcs     
env: bar/bin:/usr/local/bin:/bin:/usr/bin: No such file or directory
make: *** [deps] Error 127
➜  helmtest git:(main) ✗ PATH="/foo/bar/bin:/usr/local/bin:/bin:/usr/bin" make go-generated-srcs
+ deps
go: finding module for package github.com/stackrox/rox/pkg/buildinfo
^Cmake: *** [deps] Interrupt: 2

➜  helmtest git:(main) ✗ sb
Switched to branch 'mc/makefile-path-fix'
Your branch is up to date with 'origin/mc/makefile-path-fix'.
➜  helmtest git:(mc/makefile-path-fix) ✗ PATH="/foo bar/bin:/usr/local/bin:/bin:/usr/bin" make go-generated-srcs
+ deps
go: finding module for package github.com/stackrox/rox/pkg/buildinfo
^Cmake: *** [deps] Interrupt: 2

```