### PR TITLE
fix: automerge with automatic token

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,9 @@ name: auto-merge
 on:
   pull_request_target:
 
+permissions:
+  pull-requests: write
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
@@ -10,7 +13,7 @@ jobs:
     steps:
     - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
       with:
-        github-token: '${{ secrets.RHACS_BOT_GITHUB_TOKEN }}'
+        github-token: '${{ secrets.GITHUB_TOKEN }}'
         command: "squash and merge"
         approve: true
         target: minor


### PR DESCRIPTION
* Give write access to the automatic action github token.
* Use the automatic token in the action.

The automerge action needs a write-allow github token. Triggered by pull_request_target the action is not given the dependabot secrets:

> For workflows initiated by Dependabot (github.actor == 'dependabot[bot]') using the pull_request_target event, if the base ref of the pull request was created by Dependabot (github.actor == 'dependabot[bot]'), the GITHUB_TOKEN will be read-only and secrets are not available.
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events