### PR TITLE
chore: switch to dependabot builtin from external automerge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,19 +1,25 @@
-name: auto-merge
-
-on:
-  pull_request_target:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+name: Dependabot auto-merge
+on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
-  auto-merge:
+  dependabot:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-    - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
-      with:
-        github-token: '${{ secrets.GITHUB_TOKEN }}'
-        command: "squash and merge"
-        approve: true
-        target: minor
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+


### PR DESCRIPTION
Could we use the dependabot metadata and `gh` cli to do the auto-merge for minor/patch dependabot pr's?

re: https://issues.redhat.com/browse/ROX-25705 and the external action. It could be nice to remove one external action dependency because that action does not appear to have updated documentation around the security issue that we encountered. I think then the automerge could be integrated more with the dependabot and github repository configuration in the future: If automerge is turned on for the repo then this could be switched to auto-approve. And specific dependancies and versions can be added if needed (and following the github documentation instead of relying on the action code+docs).