### PR TITLE
fix: replace yaml lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/itchyny/gojq v0.12.17
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.3
 	helm.sh/helm/v3 v3.18.4
 	k8s.io/apimachinery v0.33.2
 	k8s.io/client-go v0.33.2
@@ -61,7 +61,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.3 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
@@ -73,6 +72,7 @@ require (
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.33.2 // indirect
 	k8s.io/apiextensions-apiserver v0.33.2 // indirect
 	k8s.io/cli-runtime v0.33.2 // indirect

--- a/internal/compiler/builtins.go
+++ b/internal/compiler/builtins.go
@@ -6,7 +6,7 @@ import (
 	"github.com/itchyny/gojq"
 	"github.com/pkg/errors"
 	"github.com/stackrox/helmtest/internal/logic"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Additional built-ins for gojq

--- a/internal/schemas/schema.go
+++ b/internal/schemas/schema.go
@@ -6,7 +6,7 @@ import (
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	"github.com/pkg/errors"
 	"github.com/stackrox/helmtest/internal/rox-imported/set"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"helm.sh/helm/v3/pkg/chartutil"
 	k8sSchema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubectl/pkg/util/openapi"

--- a/pkg/framework/spec_unmarshal.go
+++ b/pkg/framework/spec_unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/stackrox/helmtest/internal/parser"
-	yamlv3 "gopkg.in/yaml.v3"
+	yamlv3 "go.yaml.in/yaml/v3"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/kubectl/pkg/util/openapi"
 
 	"github.com/pkg/errors"
-	yamlv3 "gopkg.in/yaml.v3"
+	yamlv3 "go.yaml.in/yaml/v3"
 )
 
 // unmarshalYamlFromFileStrict unmarshals the contents of filename into out, relying on gopkg.in/yaml.v3 semantics.


### PR DESCRIPTION
`gopkg.in/yaml` is not maintained let's follow k8s recommendation and use `"go.yaml.in/yaml/v3"` alternatively we could use https://github.com/goccy/go-yaml but we already have indirect dependency to k8s version and it's a fork of `github.com/ghodss/yaml` so we can replace 2 deps with 1 without any code changes.

See:
- https://github.com/kubernetes/kubernetes/blob/8eda367f27b79adf5b41f019ede7708abee9602d/hack/unwanted-dependencies.json#L89C35-L90
- https://github.com/go-yaml/yaml/tree/v3?tab=readme-ov-file#this-project-is-unmaintained
- https://github.com/stackrox/scanner/pull/1960
- https://github.com/quay/claircore/pull/1577
- https://github.com/kubernetes-sigs/yaml/tree/master/goyaml.v3#usage
- https://github.com/stackrox/stackrox/pull/15834